### PR TITLE
Replace 42Crunch action tag with commit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,2 +1,2 @@
 - name: 42Crunch API Conformance Scan
-  uses: 42Crunch/cicd-github-actions@v1
+  uses: 42Crunch/cicd-github-actions@e2c9a02bb391932aee6ef994de06ff2c7aae9ff6


### PR DESCRIPTION
## Summary
- pin `42Crunch/cicd-github-actions` to commit SHA to reduce supply chain risk

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d3a3b61c88325a3224f44dd717006